### PR TITLE
Config Co2L for 2035) and wildcard_constraint regex (allow decimal values for h2export) update

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -76,7 +76,7 @@ wildcard_constraints:
     sopts="[-+a-zA-Z0-9\.\s]*",
     discountrate="[-+a-zA-Z0-9\.\s]*",
     demand="[-+a-zA-Z0-9\.\s]*",
-    h2export="[0-9]+m?|all",
+    h2export="[0-9]+(\.[0-9]+)",
     planning_horizons="20[2-9][0-9]|2100",
 
 

--- a/configs/scenarios_H2G/config.H2G_A_CG.yaml
+++ b/configs/scenarios_H2G/config.H2G_A_CG.yaml
@@ -40,10 +40,10 @@ scenario:
   simpl: [""]
   ll: ["copt"]
   clusters: [10]
-  opts: [Co2L0.8] # Co2L0.1 TODO per country: adjust factor (e.g. Co2L0.8 for 2035, Co2L0.1) and co2base (see below) per country and planning_horizon based on excel file
+  opts: [Co2L0.6] # Co2L0.15 TODO per country: adjust factor (e.g. Co2L0.8 for 2035, Co2L0.1) and co2base (see below) per country and planning_horizon based on excel file
   planning_horizons: # investment years for myopic and perfect; or costs year for overnight
   - 2035
-  - 2050
+  # - 2050
   sopts:
   - "3H"
   demand:

--- a/configs/scenarios_H2G/config.H2G_A_EG.yaml
+++ b/configs/scenarios_H2G/config.H2G_A_EG.yaml
@@ -40,10 +40,10 @@ scenario:
   simpl: [""]
   ll: ["copt"]
   clusters: [10]
-  opts: [Co2L0.80] # Co2L0.24 TODO per country: adjust factor (e.g. Co2L0.8 for 2035) and co2base (see below) per country and planning_horizon based on excel file
+  opts: [Co2L0.59] # Co2L0.24 TODO per country: adjust factor (e.g. Co2L0.8 for 2035) and co2base (see below) per country and planning_horizon based on excel file
   planning_horizons: # investment years for myopic and perfect; or costs year for overnight
   - 2035
-  - 2050
+  # - 2050
   sopts:
   - "3H"
   demand:

--- a/configs/scenarios_H2G/config.H2G_A_ET.yaml
+++ b/configs/scenarios_H2G/config.H2G_A_ET.yaml
@@ -40,10 +40,10 @@ scenario:
   simpl: [""]
   ll: ["copt"]
   clusters: [10]
-  opts: [Co2L0.63] # Co2L0.25 TODO per country: adjust factor (e.g. Co2L0.8 for 2035) and co2base (see below) per country and planning_horizon based on excel file
+  opts: [Co2L0.51] # Co2L0.25 TODO per country: adjust factor (e.g. Co2L0.8 for 2035) and co2base (see below) per country and planning_horizon based on excel file
   planning_horizons: # investment years for myopic and perfect; or costs year for overnight
   - 2035
-  - 2050
+  # - 2050
   sopts:
   - "3H"
   demand:

--- a/configs/scenarios_H2G/config.H2G_A_GH.yaml
+++ b/configs/scenarios_H2G/config.H2G_A_GH.yaml
@@ -40,10 +40,10 @@ scenario:
   simpl: [""]
   ll: ["copt"]
   clusters: [10]
-  opts: [Co2L0.8] # Co2L0.1 TODO per country: adjust factor (e.g. Co2L0.8 for 2035) and co2base (see below) per country and planning_horizon based on excel file
+  opts: [Co2L0.6] # Co2L0.15 TODO per country: adjust factor (e.g. Co2L0.8 for 2035) and co2base (see below) per country and planning_horizon based on excel file
   planning_horizons: # investment years for myopic and perfect; or costs year for overnight
   - 2035
-  - 2050
+  # - 2050
   sopts:
   - "3H"
   demand:

--- a/configs/scenarios_H2G/config.H2G_A_KE.yaml
+++ b/configs/scenarios_H2G/config.H2G_A_KE.yaml
@@ -43,7 +43,7 @@ scenario:
   opts: [Co2L0.05] # Co2L0.00 TODO per country: adjust factor (e.g. Co2L0.8 for 2035) and co2base (see below) per country and planning_horizon based on excel file
   planning_horizons: # investment years for myopic and perfect; or costs year for overnight
   - 2035
-  - 2050
+  # - 2050
   sopts:
   - "3H"
   demand:

--- a/configs/scenarios_H2G/config.H2G_A_MA.yaml
+++ b/configs/scenarios_H2G/config.H2G_A_MA.yaml
@@ -40,10 +40,10 @@ scenario:
   simpl: [""]
   ll: ["copt"]
   clusters: [10]
-  opts: [Co2L0.83] # Co2L0.26 TODO per country: adjust factor (e.g. Co2L0.8 for 2035) and co2base (see below) per country and planning_horizon based on excel file
+  opts: [Co2L0.62] # Co2L0.26 TODO per country: adjust factor (e.g. Co2L0.8 for 2035) and co2base (see below) per country and planning_horizon based on excel file
   planning_horizons: # investment years for myopic and perfect; or costs year for overnight
   - 2035
-  - 2050
+  # - 2050
   sopts:
   - "3H"
   demand:

--- a/configs/scenarios_H2G/config.H2G_A_NA.yaml
+++ b/configs/scenarios_H2G/config.H2G_A_NA.yaml
@@ -40,10 +40,10 @@ scenario:
   simpl: [""]
   ll: ["copt"]
   clusters: [10]
-  opts: [Co2L0.8] # Co2L0.1 # TODO per country: adjust factor (e.g. Co2L0.8 for 2035) and co2base (see below) per country and planning_horizon based on excel file
+  opts: [Co2L0.6] # Co2L0.15 # TODO per country: adjust factor (e.g. Co2L0.8 for 2035) and co2base (see below) per country and planning_horizon based on excel file
   planning_horizons: # investment years for myopic and perfect; or costs year for overnight
   - 2035
-  - 2050
+  # - 2050
   sopts:
   - "3H"
   demand:

--- a/configs/scenarios_H2G/config.H2G_A_NG.yaml
+++ b/configs/scenarios_H2G/config.H2G_A_NG.yaml
@@ -40,10 +40,10 @@ scenario:
   simpl: [""]
   ll: ["copt"]
   clusters: [10]
-  opts: [Co2L0.83] # Co2L0.30 TODO per country: adjust factor (e.g. Co2L0.8 for 2035) and co2base (see below) per country and planning_horizon based on excel file
+  opts: [Co2L0.62] # Co2L0.30 TODO per country: adjust factor (e.g. Co2L0.8 for 2035) and co2base (see below) per country and planning_horizon based on excel file
   planning_horizons: # investment years for myopic and perfect; or costs year for overnight
   - 2035
-  - 2050
+  # - 2050
   sopts:
   - "3H"
   demand:

--- a/configs/scenarios_H2G/config.H2G_A_TN.yaml
+++ b/configs/scenarios_H2G/config.H2G_A_TN.yaml
@@ -40,10 +40,10 @@ scenario:
   simpl: [""]
   ll: ["copt"]
   clusters: [10]
-  opts: [Co2L] # TODO per country: adjust factor (e.g. Co2L0.8 for 2035) and co2base (see below) per country and planning_horizon based on excel file
+  opts: [Co2L0.6] # Co2L0.15 TODO per country: adjust factor (e.g. Co2L0.8 for 2035) and co2base (see below) per country and planning_horizon based on excel file
   planning_horizons: # investment years for myopic and perfect; or costs year for overnight
   - 2035
-  - 2050
+  # - 2050
   sopts:
   - "3H"
   demand:

--- a/configs/scenarios_H2G/config.H2G_A_TZ.yaml
+++ b/configs/scenarios_H2G/config.H2G_A_TZ.yaml
@@ -40,10 +40,10 @@ scenario:
   simpl: [""]
   ll: ["copt"]
   clusters: [10]
-  opts: [Co2L0.8] # Co2L0.1  # TODO per country: adjust factor (e.g. Co2L0.8 for 2035) and co2base (see below) per country and planning_horizon based on excel file
+  opts: [Co2L0.6] # Co2L0.15  # TODO per country: adjust factor (e.g. Co2L0.8 for 2035) and co2base (see below) per country and planning_horizon based on excel file
   planning_horizons: # investment years for myopic and perfect; or costs year for overnight
   - 2035
-  - 2050
+  # - 2050
   sopts:
   - "3H"
   demand:

--- a/configs/scenarios_H2G/config.H2G_A_ZA.yaml
+++ b/configs/scenarios_H2G/config.H2G_A_ZA.yaml
@@ -40,10 +40,10 @@ scenario:
   simpl: [""]
   ll: ["copt"]
   clusters: [10]
-  opts: [Co2L0.71] # Co2L0.14 TODO per country: adjust factor (e.g. Co2L0.8 for 2035) and co2base (see below) per country and planning_horizon based on excel file
+  opts: [Co2L0.63] # Co2L0.14 TODO per country: adjust factor (e.g. Co2L0.8 for 2035) and co2base (see below) per country and planning_horizon based on excel file
   planning_horizons: # investment years for myopic and perfect; or costs year for overnight
   - 2035
-  - 2050
+  #- 2050
   sopts:
   - "3H"
   demand:


### PR DESCRIPTION
## Changes proposed in this Pull Request

* config update: use Co2L values for 2035 instead of 2030
* fix: redefine h2export regex wildcard_constraint to allow digits + optional dot followed by more digits (decimals)


## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
